### PR TITLE
Update hashsalt.js

### DIFF
--- a/lib/hashsalt.js
+++ b/lib/hashsalt.js
@@ -21,7 +21,7 @@ var password = function(password) {
 			}
 
 			var calcHash = function() {
-				crypto.pbkdf2(password, salt, iterations, 64, 'sha1', function(err, key) {
+				crypto.pbkdf2(password, salt, iterations, 20, 'sha1', function(err, key) {
 					if(err)
 						return callback(err);
 					var res = 'pbkdf2$' + iterations + 
@@ -32,7 +32,7 @@ var password = function(password) {
 			};
 
 			if(!salt) {
-				crypto.randomBytes(64, function(err, gensalt) {
+				crypto.randomBytes(5, function(err, gensalt) {
 					if(err)
 						return callback(err);
 					salt = gensalt;


### PR DESCRIPTION
line 24: change bytes from 64 to 20 (160bit) - SHA1 outputs a 160bit digest

line 35: change bytes from 64 to 5 - some may consider this weak, but it still provides over 1 trillion salt possibilities which is more that enough to serve the purpose of a salt.  The two primary purposes of a salt are to avoid two(or more) same passwords from showing the same hash result, and to make rainbow tables impractical (a 1MB plain rainbow table would become 1exabyte after recalculating with a trillion salts ~ this is impractical for anyone but organizations like NSA/Google/Apple/Microsoft/Amazon/etc.  Why would one of those organizations need to hack your node.js and/or database and steal a password??  If they had a need and where that determined to break a password on your system they would probably resort to something else like MITM, social engineering, key loggers, blackmail, or torture.  Or perhaps hack your system and have node simply send them the plain password.  So lets get real.... 5bytes is plenty sufficient for its intended purpose.  Honestly, it's not like a bigger salt is bad, I just wanted the total length of this function to be 64 characters :-) and shrinking the salt allowed me to do so, and doesn't introduce any real or practical risk.
